### PR TITLE
Add metric count-up animation and clean up footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,6 +797,49 @@
         container.appendChild(card);
       });
 
+      // Count-up animation for impact metrics
+      (function() {
+        function parseMetric(text) {
+          // Extracts prefix (e.g. "$"), number (e.g. 9.5), suffix (e.g. "M", "+")
+          const match = text.match(/^([^0-9]*)(\d+(?:\.\d+)?)(.*)$/);
+          if (!match) return null;
+          return { prefix: match[1], value: parseFloat(match[2]), suffix: match[3] };
+        }
+
+        function animateCounter(el, metric, duration) {
+          const start = performance.now();
+          const isFloat = metric.value % 1 !== 0;
+          function step(now) {
+            const elapsed = now - start;
+            const progress = Math.min(elapsed / duration, 1);
+            // Ease out cubic
+            const eased = 1 - Math.pow(1 - progress, 3);
+            const current = eased * metric.value;
+            el.textContent = metric.prefix + (isFloat ? current.toFixed(1) : Math.floor(current)) + metric.suffix;
+            if (progress < 1) requestAnimationFrame(step);
+            else el.textContent = metric.prefix + metric.value + metric.suffix;
+          }
+          requestAnimationFrame(step);
+        }
+
+        const observer = new IntersectionObserver(function(entries) {
+          entries.forEach(function(entry) {
+            if (!entry.isIntersecting) return;
+            const impactEl = entry.target;
+            observer.unobserve(impactEl); // never re-animate
+            impactEl.querySelectorAll('strong').forEach(function(strong) {
+              const metric = parseMetric(strong.textContent.trim());
+              if (!metric) return;
+              animateCounter(strong, metric, 1200);
+            });
+          });
+        }, { threshold: 0.4 });
+
+        document.querySelectorAll('.project-impact').forEach(function(el) {
+          observer.observe(el);
+        });
+      })();
+
       // About Me card
       const aboutCard = document.createElement('div');
       aboutCard.className = 'about-card';

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -28,15 +28,10 @@
           </ul>
         </div>
       </div>
-      <div class="footer-status">
-        <span class="status-dot"></span>
-        <span>All systems operational</span>
-      </div>
     </div>
     <div class="footer-bottom">
       <div class="footer-bottom-left">
         <p>© 2026</p>
-        <p class="visitor-location">Last visitor from <span id="visitor-location">...</span></p>
       </div>
       <div class="theme-switcher">
         <button class="theme-option" data-theme="light" aria-label="Light mode">
@@ -104,24 +99,4 @@
     }
   })();
 
-  // Fetch visitor location
-  (function() {
-    fetch('https://ipapi.co/json/')
-      .then(response => response.json())
-      .then(data => {
-        const locationEl = document.getElementById('visitor-location');
-        if (data.city && data.region) {
-          locationEl.textContent = `${data.city}, ${data.region}`;
-        } else if (data.city && data.country_name) {
-          locationEl.textContent = `${data.city}, ${data.country_name}`;
-        } else if (data.country_name) {
-          locationEl.textContent = data.country_name;
-        } else {
-          locationEl.textContent = 'somewhere on Earth';
-        }
-      })
-      .catch(() => {
-        document.getElementById('visitor-location').textContent = 'parts unknown';
-      });
-  })();
 </script>


### PR DESCRIPTION
## Summary
- Impact metrics on project cards now count up when scrolled into view, using IntersectionObserver — fires once and never replays
- Removed "All systems operational" status indicator from footer
- Removed "Last visitor from" location tracker and associated API call from footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)